### PR TITLE
Add support for subtitle field (iOS)

### DIFF
--- a/src/ExpoMessage.php
+++ b/src/ExpoMessage.php
@@ -14,6 +14,13 @@ class ExpoMessage
     protected $title;
 
     /**
+     * The message subtitle (iOS).
+     *
+     * @var string
+     */
+    protected $subtitle;
+
+    /**
      * The message body.
      *
      * @var string
@@ -96,6 +103,19 @@ class ExpoMessage
     public function title(string $value): ExpoMessage
     {
         $this->title = $value;
+
+        return $this;
+    }
+
+    /**
+     * Set the message subtitle (iOS).
+     *
+     * @param  string  $value
+     * @return $this
+     */
+    public function subtitle(string $value): ExpoMessage
+    {
+        $this->subtitle = $value;
 
         return $this;
     }
@@ -230,6 +250,9 @@ class ExpoMessage
             'data'      =>  $this->jsonData,
             'priority'  =>  $this->priority,
         ];
+        if (! empty($this->subtitle)) {
+            $message['subtitle'] = $this->subtitle;
+        }
         if (! empty($this->channelId)) {
             $message['channelId'] = $this->channelId;
         }

--- a/tests/ExpoMessageTest.php
+++ b/tests/ExpoMessageTest.php
@@ -45,6 +45,13 @@ class ExpoMessageTest extends \PHPUnit\Framework\TestCase
     }
 
     /** @test */
+    public function it_can_set_the_subtitle()
+    {
+        $this->message->subtitle('Subtitle');
+        $this->assertEquals('Subtitle', Arr::get($this->message->toArray(), 'subtitle'));
+    }
+
+    /** @test */
     public function it_can_set_the_body()
     {
         $this->message->body('Body');


### PR DESCRIPTION
[Expo push notifications](https://expo.dev/notifications) can take a `subtitle` field that is passed on to iOS devices. This PR adds support for this field.

## Test Plan

### Verify in our own app

We're using `laravel-notification-channels/expo` in our application. I copied the changes to `ExpoMessage.php` from this PR into the vendor directory, and updated our code to set the `subtitle` field:

```
        return ExpoMessage::create()
            ->title($title)
            ->subtitle($subtitle)
            ->body($body)
            ->enableSound()
            ->setJsonData($jsonData)
            ->badge(1);
```

I was able to confirm that the push notification that is sent via Expo does in fact include a subtitle ("Notification Tests" in this case):

![IMG_AAFBE111BB8B-1](https://user-images.githubusercontent.com/165856/225527000-1627472f-3548-4b48-9c7b-899456c40132.jpeg)

### Run tests

```
$ composer test
> phpunit
PHPUnit 8.5.33 by Sebastian Bergmann and contributors.

................                                                  16 / 16 (100%)

Time: 78 ms, Memory: 14.00 MB

OK (16 tests, 17 assertions)
```